### PR TITLE
fix: webview endpoint 변경, feat: expo, ios, android clientId 추가

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,7 +15,8 @@
     "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.ww8007.pickly"
+      "bundleIdentifier": "com.ww8007.pickly",
+      "buildNumber": "3"
     },
     "android": {
       "adaptiveIcon": {

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -8,7 +8,7 @@ export default function App() {
     <SafeAreaView style={styles.safeArea}>
       <WebView
         style={styles.container}
-        source={{ uri: 'http://localhost:3000/' }}
+        source={{ uri: 'https://app.pickly.today' }}
       />
     </SafeAreaView>
   );

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -4,7 +4,7 @@ import { View } from '../components/Themed';
 import Button from '../ui/Button';
 import Colors from '../constants/Colors';
 import { Text } from '../ui/Text';
-import useGetGoogleAuth from '../auth/useGetGoggleAuth';
+import useGetGoogleAuth from '../auth/useGetGoogleAuth';
 import { useEffect, useState } from 'react';
 import useGetAppleAuth from '../auth/useGetAppleAuth';
 import * as AppleAuthentication from 'expo-apple-authentication';

--- a/auth/useGetGoogleAuth.ts
+++ b/auth/useGetGoogleAuth.ts
@@ -14,8 +14,9 @@ import { useEffect } from 'react';
 
 const useGetGoogleAuth = () => {
   const [request, response, promptAsync] = Google.useIdTokenAuthRequest({
-    clientId: process.env.GOOGLE_CLIENT_ID,
-    expoClientId: 'GOOGLE_GUID.apps.googleusercontent.com',
+    expoClientId: process.env.EXPO_CLIENT_ID || '',
+    iosClientId: process.env.IOS_CLIENT_ID || '',
+    androidClientId: process.env.ANDROID_CLIENT_ID || '',
   });
   const auth = getAuth();
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "firebase": "^9.21.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-native": "0.71.7",
+    "react-native": "0.71.8",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.20.0",
     "react-native-svg": "13.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7563,10 +7563,10 @@ react-native-codegen@^0.71.5:
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
 
-react-native-gradle-plugin@^0.71.17:
-  version "0.71.17"
-  resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.17.tgz#cf780a27270f0a32dca8184eff91555d7627dd00"
-  integrity sha512-OXXYgpISEqERwjSlaCiaQY6cTY5CH6j73gdkWpK0hedxtiWMWgH+i5TOi4hIGYitm9kQBeyDu+wim9fA8ROFJA==
+react-native-gradle-plugin@^0.71.18:
+  version "0.71.19"
+  resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.19.tgz#3379e28341fcd189bc1f4691cefc84c1a4d7d232"
+  integrity sha512-1dVk9NwhoyKHCSxcrM6vY6cxmojeATsBobDicX0ZKr7DgUF2cBQRTKsimQFvzH8XhOVXyH8p4HyDSZNIFI8OlQ==
 
 react-native-safe-area-context@4.5.0:
   version "4.5.0"
@@ -7610,10 +7610,10 @@ react-native-webview@11.26.0:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"
 
-react-native@0.71.7:
-  version "0.71.7"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.71.7.tgz#d0ae409f6ee4fc7e7a876b4ca9d8d28934133228"
-  integrity sha512-Id6iRLS581fJMFGbBl1jP5uSmjExtGOvw5Gvh7694zISXjsRAsFMmU+izs0pyCLqDBoHK7y4BT7WGPGw693nYw==
+react-native@0.71.8:
+  version "0.71.8"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.71.8.tgz#4314145341c49448cf7465b93ced52a433a5e191"
+  integrity sha512-ftMAuhpgTkbHU9brrqsEyxcNrpYvXKeATY+if22Nfhhg1zW+6wn95w9otwTnA3xHkljPCbng8mUhmmERjGEl7g==
   dependencies:
     "@jest/create-cache-key-function" "^29.2.1"
     "@react-native-community/cli" "10.2.2"
@@ -7640,7 +7640,7 @@ react-native@0.71.7:
     promise "^8.3.0"
     react-devtools-core "^4.26.1"
     react-native-codegen "^0.71.5"
-    react-native-gradle-plugin "^0.71.17"
+    react-native-gradle-plugin "^0.71.18"
     react-refresh "^0.4.0"
     react-shallow-renderer "^16.15.0"
     regenerator-runtime "^0.13.2"


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #11
- PR의 메인 내용

1. webview endpoint 실 주소로 변경
2. expo 로그인에 필요한 expo, ios, android client Id 추가

<br>

## 🔨 작업 사항 (필수)

- [x] webview endpoint 수정
- [x] expo clientId 추가
- [x] ios clientId 추가
- [x] android clientId 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
#6 에서 문제가 있었던 env가 eas 빌드 시에 말썽을 일으킴
이게 env가 로드되는 타이밍이 firebase config 자체보다 늦은걸로 판별됨