### PR TITLE
fix: webview 뒤로 가기 동작 추가 및 로딩 화면 도착시 webview로 이동하도록 설정 추가

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,7 +4,12 @@ import {
   ThemeProvider,
 } from '@react-navigation/native';
 import { SplashScreen, Stack } from 'expo-router';
-import { AppState, AppStateStatus, useColorScheme } from 'react-native';
+import {
+  AppState,
+  AppStateStatus,
+  BackHandler,
+  useColorScheme,
+} from 'react-native';
 import useSettingFont from '../common/hooks/useSettingFont';
 import { AuthProvider } from '../auth/AuthContext';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -59,6 +64,15 @@ function RootLayoutNav() {
       },
     },
   });
+
+  // 사용자의 뒤로가기 버튼을 제거
+  useEffect(() => {
+    const backHandler = BackHandler.addEventListener(
+      'hardwareBackPress',
+      () => true,
+    );
+    return () => backHandler.remove();
+  }, []);
 
   const appState = useRef(AppState.currentState);
   const [activeAppState, setActiveAppState] = useState(appState.current);

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,7 +1,28 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Loading from '../common/ui/Loading';
+import { usePathname, useRouter } from 'expo-router';
+import useAuthContext from '../auth/useAuthContext';
+import { useGetMemberId } from '../auth/api/login';
 
 const index = () => {
+  const { user } = useAuthContext();
+
+  const router = useRouter();
+  // NOTE : usePathname은 라우터가 바뀔때마다 pathname을 가져온다.
+  // 이를 이용해서 로딩 화면에서 로그인이 되어있는지 확인하고
+  // 로그인이 되어있다면 webview로 이동시킨다.
+  usePathname();
+
+  const { data: serverMemberId } = useGetMemberId({
+    token: user?.token,
+  });
+
+  useEffect(() => {
+    if (serverMemberId) {
+      router.push('webview');
+    }
+  }, [serverMemberId, router]);
+
   return <Loading />;
 };
 

--- a/app/webview.tsx
+++ b/app/webview.tsx
@@ -62,6 +62,7 @@ export default function App() {
           // source={{
           //   uri: `http://localhost:3000${webviewURL[mode](userInfo?.id)}`,
           // }}
+          allowsBackForwardNavigationGestures={true}
         />
       </SafeAreaView>
     </>


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #39
- PR의 메인 내용

1. 웹뷰 기본 뒤로 가기 동작 가능 하도록 설정
2. loading 화면 도착시 다시 webview 화면으로 이동 하도록 설정

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] webview allowsBackForwardNavigationGestures 설정 추가
- [x] 사용자의 기본 뒤로가기 동작 제어
- [x] Loading 화면에서 webview 화면으로 원복 로직 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
