### PR TITLE
feat: 유저 정보 없을 때 로그인 화면으로 보내도록 추가

### DIFF
--- a/app/initialWebview.tsx
+++ b/app/initialWebview.tsx
@@ -27,6 +27,7 @@ import Constants from 'expo-constants';
 import { webviewBridge } from '../common/util/webviewBridge';
 import useNotification from '../notification/hooks/useNotification';
 import { captureScreen } from 'react-native-view-shot';
+import { useRouter } from 'expo-router';
 
 export type MODE = 'SIGN_IN' | 'SIGN_UP';
 const clientUrl = Constants.expoConfig?.extra?.clientUrl || '';
@@ -122,6 +123,8 @@ const App = () => {
     memberId: userInfo?.id ?? 0,
   });
 
+  // 4. 웹뷰 메시지
+  const router = useRouter();
   const onWebViewMessage = (event: WebViewMessageEvent) => {
     if (event.nativeEvent.data === 'login') {
       webviewBridge(webviewRef, 'login', {
@@ -130,12 +133,15 @@ const App = () => {
       })();
       setLoading(false);
     }
-    if (event.nativeEvent.data == 'notification') {
+    if (event.nativeEvent.data === 'notification') {
       requestUserPermission();
     }
-    if (event.nativeEvent.data == 'goBack') {
+    if (event.nativeEvent.data === 'goBack') {
       captureScreenFn(setSnapshotUri);
       setIsGoingBack(true);
+    }
+    if (event.nativeEvent.data === 'signUp') {
+      router.replace('login');
     }
   };
 

--- a/auth/api/login.ts
+++ b/auth/api/login.ts
@@ -104,7 +104,6 @@ export const useGETMemberInfo = (params: GETUserInfoQueryParams) => {
       enabled: params.loginId !== 0,
       onSuccess: (data) => {
         if (data.nickname) params.setMode('SIGN_IN');
-        console.log('data:', data);
       },
       onError: (error) => {
         console.log('error:', error);


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #55
- PR의 메인 내용

1. 유저 정보 없을 때 로그인 페이지로 보내도록 설정

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] 웹뷰에서 signUp 브릿지 받으면 router replace 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
