### PR TITLE
fix: 애플 로그인 이름 사용 되도록 수정

### DIFF
--- a/app/initialWebview.tsx
+++ b/app/initialWebview.tsx
@@ -185,9 +185,9 @@ const App = () => {
   const onWebViewMessage = (event: WebViewMessageEvent) => {
     const data = JSON.parse(event.nativeEvent.data) as WebviewOnMessage;
     if (data.message === 'login') {
-      if (serverMemberId) {
+      if (serverMemberId && user) {
         webviewBridge(webviewRef, 'login', {
-          token: user?.token,
+          token: user.token,
           memberId: serverMemberId,
         })();
       }

--- a/auth/AuthContext.tsx
+++ b/auth/AuthContext.tsx
@@ -1,14 +1,16 @@
+import auth from '@react-native-firebase/auth';
+import { useRouter } from 'expo-router';
 import {
   createContext,
-  useEffect,
-  useReducer,
   useCallback,
+  useEffect,
   useMemo,
+  useReducer,
   useState,
 } from 'react';
-import auth from '@react-native-firebase/auth';
+import useUserStore from '../common/state/user';
 import { useGetMemberId } from './api/login';
-import { useRouter } from 'expo-router';
+import { usePutUserInfoQuery } from './api/user';
 
 export type ActionMapType<M extends { [index: string]: any }> = {
   [Key in keyof M]: M[Key] extends undefined
@@ -21,7 +23,12 @@ export type ActionMapType<M extends { [index: string]: any }> = {
       };
 };
 
-export type AuthUserType = null | Record<string, any>;
+interface User {
+  token: string;
+  [key: string]: any;
+}
+
+export type AuthUserType = User | null;
 
 export type AuthStateType = {
   isInitialized: boolean;
@@ -30,7 +37,7 @@ export type AuthStateType = {
 
 export type Auth0ContextType = {
   isInitialized: boolean;
-  user: AuthUserType;
+  user: AuthUserType | null;
   logout: () => void;
 };
 
@@ -99,6 +106,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
     token: token,
   });
 
+  const { mutate } = usePutUserInfoQuery({ memberId: serverMemberId ?? 0 });
+  const { name } = useUserStore();
   useEffect(() => {
     if (isGetMemberIdLoading) return;
     if (serverMemberId === undefined && isGetMemberIdError) {
@@ -106,6 +115,17 @@ export function AuthProvider({ children }: AuthProviderProps) {
       return;
     }
     if (serverMemberId && state.user) {
+      if (name && serverMemberId) {
+        mutate({
+          memberId: serverMemberId,
+          putData: {
+            name,
+            nickname: name.slice(0, 3) + '-+@',
+            profileEmoji: '🐶',
+          },
+          token: token,
+        });
+      }
       router.push('initialWebview');
     }
   }, [serverMemberId, isGetMemberIdLoading, isGetMemberIdError, state]);
@@ -119,7 +139,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
             user: {
               ...user,
               displayName: user?.displayName,
-              token: await user?.getIdToken(),
+              token: (await user?.getIdToken()) ?? '',
             },
           },
         });

--- a/auth/AuthContext.tsx
+++ b/auth/AuthContext.tsx
@@ -12,6 +12,8 @@ import useUserStore from '../common/state/user';
 import { useGetMemberId } from './api/login';
 import { usePutUserInfoQuery } from './api/user';
 
+const PREFIX = '-+@*' as const;
+
 export type ActionMapType<M extends { [index: string]: any }> = {
   [Key in keyof M]: M[Key] extends undefined
     ? {
@@ -120,7 +122,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
           memberId: serverMemberId,
           putData: {
             name,
-            nickname: name.slice(0, 3) + '-+@',
+            nickname: PREFIX + generateRandomString(3),
             profileEmoji: '🐶',
           },
           token: token,
@@ -185,3 +187,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
     </AuthContext.Provider>
   );
 }
+
+const generateRandomString = (num: number) => {
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+  let result = '';
+  const charactersLength = characters.length;
+  for (let i = 0; i < num; i++) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+  }
+
+  return result;
+};

--- a/auth/api/login.ts
+++ b/auth/api/login.ts
@@ -87,11 +87,11 @@ const getUserInfo = async ({ loginId, token }: GETUserInfoRequest) => {
 
 export interface GETUserInfoQueryParams {
   loginId: number;
-  setMode: (mode: MODE) => void;
+  setMode?: (mode: MODE) => void;
   token?: string;
 }
 
-const GET_MEMBER_INFO_KEY = (params: GETUserInfoQueryParams) => [
+export const GET_MEMBER_INFO_KEY = (params: GETUserInfoQueryParams) => [
   'GET_MEMBER_INFO',
   params.loginId,
 ];
@@ -103,11 +103,11 @@ export const useGETMemberInfo = (params: GETUserInfoQueryParams) => {
     {
       enabled: params.loginId !== 0,
       onSuccess: (data) => {
-        if (data.nickname) params.setMode('SIGN_IN');
+        if (data.nickname) params.setMode && params.setMode('SIGN_IN');
       },
       onError: (error) => {
         console.log('error:', error);
-        params.setMode('SIGN_UP');
+        params.setMode && params.setMode('SIGN_UP');
       },
     },
   );

--- a/auth/api/user.ts
+++ b/auth/api/user.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import client from '../../lib/client';
+import { GET_MEMBER_INFO_KEY } from './login';
+
+interface RequestInterface {
+  memberId: number;
+  putData: {
+    name: string;
+    nickname: string;
+    profileEmoji: string;
+  };
+  token?: string;
+}
+
+const putUserInfo = async ({ memberId, putData, token }: RequestInterface) => {
+  const { data } = await client({
+    method: 'put',
+    url: '/members/me',
+    params: { memberId },
+    data: putData,
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  return data;
+};
+
+export interface PutAPIRequest {
+  memberId: number;
+}
+export const usePutUserInfoQuery = ({ memberId }: PutAPIRequest) => {
+  const queryClient = useQueryClient();
+
+  return useMutation(putUserInfo, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(GET_MEMBER_INFO_KEY({ loginId: memberId }));
+    },
+  });
+};

--- a/auth/useGetAppleAuth.ts
+++ b/auth/useGetAppleAuth.ts
@@ -1,13 +1,16 @@
 import appleAuth from '@invertase/react-native-apple-authentication';
 import auth from '@react-native-firebase/auth';
+import useUserStore from '../common/state/user';
 import useSignInUser from './useSignInUser';
 
 const useGetAppleAuth = () => {
   const { signInUser } = useSignInUser();
+  const { setName } = useUserStore();
+
   const signInWithApple = async () => {
     // Start the sign-in request
     const appleAuthRequestResponse = await appleAuth.performRequest({
-      requestedOperation: appleAuth.Operation.LOGIN,
+      requestedOperation: appleAuth.Operation.REFRESH,
       requestedScopes: [appleAuth.Scope.EMAIL, appleAuth.Scope.FULL_NAME],
     });
 
@@ -17,11 +20,15 @@ const useGetAppleAuth = () => {
     }
 
     // Create a Firebase credential from the response
-    const { identityToken, nonce } = appleAuthRequestResponse;
+    const { identityToken, nonce, fullName } = appleAuthRequestResponse;
     const appleCredential = auth.AppleAuthProvider.credential(
       identityToken,
       nonce,
     );
+
+    if (fullName?.givenName && fullName?.familyName) {
+      setName(`${fullName?.givenName}${fullName?.familyName}`);
+    }
 
     // Sign the user in with the credential
     return auth()

--- a/common/state/user.ts
+++ b/common/state/user.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface User {
+  name: string;
+  setName: (name: string) => void;
+}
+
+const useUserStore = create<User>((set) => ({
+  name: '',
+  setName: (name) => set({ name }),
+}));
+
+export default useUserStore;


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #87
- PR의 메인 내용

1. 애플 로그인에서 이름 가져와서 사용 하도록 수정
2. 닉네임 임시 설정 추가

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] 애플 로그인에서 이름 받아와서 처리하는 로직 추가
- [x] 닉네임 임시 설정값 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
